### PR TITLE
Updated lsg styles in line with Atom's depreciation of the shadow dom

### DIFF
--- a/styles/lsg.less
+++ b/styles/lsg.less
@@ -1,6 +1,6 @@
 @import 'ui-variables';
 
-atom-text-editor::shadow .source.lsg {
+atom-text-editor.editor .syntax--source.syntax--lsg {
   @highlight-background: mix(@text-color-highlight, @app-background-color, 20%);
   .highlight.lsg {
     background: @highlight-background;


### PR DESCRIPTION
Following Atom's depreciation of shadow DOM encapsulation, I've followed their instructions and updated the styles accordingly. This is covered in #2.

Tested it locally in dev mode and it worked as expected:

![image](https://cloud.githubusercontent.com/assets/449385/23801386/e82e3244-05a7-11e7-87de-b063a8b796fe.png)

Again, thanks for all your hard work on LSG. 👍 